### PR TITLE
Context menu options match menu options

### DIFF
--- a/app/config/lang/en.js
+++ b/app/config/lang/en.js
@@ -56,7 +56,7 @@ const en = {
 
   // Context menu Memory management
   'labels.ctmemory.config': 'Configure',
-  'labels.ctmemory.editor': 'Editor',
+  'labels.ctmemory.editor': 'Hex editor',
   'labels.ctmemory.controllabel': 'MEMORY',
 
   // Uc

--- a/app/config/lang/es.js
+++ b/app/config/lang/es.js
@@ -26,14 +26,14 @@ const es = {
   'labels.menu.menu_running_instruction': '[F8] Instrucción completa',
   'labels.menu.menu_running_run': '[F9] Ejecutar',
   'labels.menu.menu_running_stop': '[F9] Detener',
-  'labels.menu.menu_running_signalselect': '[F6] Seleccionar Señales',
+  'labels.menu.menu_running_signalselect': '[F6] Seleccionar señales',
   'labels.menu.menu_running_mode_normal': '[F5] Cambiar modo',
   'labels.menu.menu_running_mode_manual': '[F5] Cambiar modo',
   'labels.menu.menu_running_reset': '[Ctrl+F10] Reiniciar',
   'labels.menu.menu_utils': 'Utilidades',
   'labels.menu.menu_utils_mem': 'Memoria',
   'labels.menu.menu_utils_mem_config': 'Configurar',
-  'labels.menu.menu_utils_mem_edit': 'Editor Hexadecimal',
+  'labels.menu.menu_utils_mem_edit': 'Editor hexadecimal',
   'labels.menu.menu_utils_io': 'E/S',
   'labels.menu.menu_utils_io_keyboard': 'Conectar Teclado',
   'labels.menu.menu_utils_io_screen': 'Conectar Pantalla',
@@ -56,7 +56,7 @@ const es = {
 
   // Context menu Memory management
   'labels.ctmemory.config': 'Configurar',
-  'labels.ctmemory.editor': 'Editor',
+  'labels.ctmemory.editor': 'Editor hexadecimal',
   'labels.ctmemory.controllabel': 'MEMORIA',
 
   // Uc


### PR DESCRIPTION
Context menu options match menu options. In addition "Señales" is capitalized as the rest of the menu options.