### PR TITLE
Hold signal selector and clear selected signals on sending signals to CU

### DIFF
--- a/app/view/navigation/signalselection.js
+++ b/app/view/navigation/signalselection.js
@@ -243,6 +243,13 @@ class SignalSelector {
       try {
         SignalSet.validateSignalSet(_this.sset.signals, CT)
         _this._event_SaveSignals(e)
+    		// Clear selected signals once sent to the control unit
+    		// Needs refactoring: raise btdeactivate click event		
+    		const tmpsignals = Array.from(signalPanel.element.querySelectorAll('input[type="checkbox"]'))
+    		tmpsignals.forEach((item) => {
+    		item.checked = false
+    		})
+    		_this.sset.reset()            
       } catch (e) {
         alert(e.message)
       }

--- a/app/view/navigation/viewactions.js
+++ b/app/view/navigation/viewactions.js
@@ -100,7 +100,9 @@ class ViewActions extends Observable {
       document.querySelector('#wmng').append(w.dom.element)
       signalmng.onSave(function () {
         ct.cpu.uc.loadSignals(sim.control.selectedSignals)
-        wm.remove(w)
+        // Do not close the signal selector on sending the signals to the control unit.
+        // The user must click X to close. Uncomment next line to change this behavior.
+		    // wm.remove(w)
       })
     }
   }


### PR DESCRIPTION
Clear selected signals needs refactoring: raise btdeactivate click event instead of the proposed instructions.