### PR TITLE
Fix label typo in en.js

### DIFF
--- a/app/config/lang/en.js
+++ b/app/config/lang/en.js
@@ -98,7 +98,7 @@ const en = {
   'labels.deviceform.form_address': 'Base addr.',
   'labels.deviceform.form_vector': 'Int. number (0-255)',
   'labels.deviceform.form_priority': 'Priority. (0-255)',
-  'labels.deviceform.form_int': 'Generares int.',
+  'labels.deviceform.form_int': 'Generates int.',
 
   // Keyboard
   'labels.ctkeyboard.buffer': 'BUFFER',


### PR DESCRIPTION
I am not sure whether the best label is 'Generates int.' or 'Generate int.', but 'Generares int.' is a typo.