### PR TITLE
Show translated label on Caps Lock keyboard key

### DIFF
--- a/app/view/ctperipherals/keyboard.js
+++ b/app/view/ctperipherals/keyboard.js
@@ -103,14 +103,15 @@ class CTKeyboard extends Observer {
     const _this = this
     const button = _jsc({ s: 'button' })
     button.addClass('keyboard-button')
-    button.text(value)
-
     switch (value) {
       case ' ':button.addClass('keyboard-button-space')
-
+        button.text(value)
         break
       case '#': button.addClass('keyboard-button-caps')
+        button.text(_jStr(CTKeyboard.labels.caps).translate())
         break
+      default:
+        button.text(value)
     }
 
     button.on('click', function () {


### PR DESCRIPTION
## Summary
- The Caps Lock keyboard button was displaying the raw `#` marker used internally to identify the key
- Now it shows the proper localized label: "Caps lock" (EN) / "Bloq. May." (ES)

## Test plan
- [x] All 142 existing tests pass
- [x] Verify the Caps Lock key label displays correctly in English
- [x] Verify the Caps Lock key label displays correctly in Spanish

🤖 Generated with [Claude Code](https://claude.com/claude-code)