### PR TITLE
Fix inverted bit 1 polarity in screen control register

### DIFF
--- a/app/config/version.js
+++ b/app/config/version.js
@@ -1,1 +1,1 @@
-export const version = 'v1.0.3';
+export const version = 'v1.0.4';

--- a/app/control/devices/screen.js
+++ b/app/control/devices/screen.js
@@ -48,7 +48,7 @@ class Screen extends Device {
    */
   reset () {
     this._positions = []
-    this.controlregister = 0x0002
+    this.controlregister = 0x0000
     this.reportUpdate()
   }
 
@@ -75,7 +75,7 @@ class Screen extends Device {
    * @method powerOn Turn on the device
    */
   powerOn () {
-    this.setPos(120, Bitop.on(this.controlregister, 1))
+    this.setPos(120, Bitop.off(this.controlregister, 1))
     // this.reportUpdate()
   }
 
@@ -83,15 +83,15 @@ class Screen extends Device {
    * @method powerOff Turn off the device
    */
   powerOff () {
-    this.setPos(120, Bitop.off(this.controlregister, 1))
+    this.setPos(120, Bitop.on(this.controlregister, 1))
   }
 
   /**
    * @method isOn Check if the device is on
-   * @returns {boolean} True if the device is on
+   * @returns {boolean} True if the device is on (bit 1 = 1 means OFF per spec)
    */
   isOn () {
-    return Bitop.isOn(this.controlregister, 1)
+    return !Bitop.isOn(this.controlregister, 1) // Bit 1 = 1 means OFF per spec
   }
 
   /**

--- a/tests/devices/screen.test.js
+++ b/tests/devices/screen.test.js
@@ -62,9 +62,52 @@ test('Test powered off no characters', () => {
   expect(pantalla.positions.length).toBe(0)
   pantalla.powerOn()
   expect(pantalla.positions.length).toBe(chars.length)
-  pantalla.setPos(120, 0x0003)
+  pantalla.setPos(120, 0x0001)
   expect(pantalla.isOn()).toBe(true)
   expect(pantalla.positions.length).toBe(0)
+})
+
+describe('Control register bit 0 (clear) and bit 1 (power off)', () => {
+  const writeChars = (pantalla, chars) => {
+    chars.split('').forEach((k, i) => {
+      pantalla.setPos(i, k.charCodeAt(0) & 0x00FF)
+    })
+  }
+
+  test('0x0000 - screen stays on, no clear', () => {
+    const pantalla = new Screen('Pantalla 1', 0xF000)
+    writeChars(pantalla, 'abc')
+    pantalla.setPos(120, 0x0000)
+    expect(pantalla.isOn()).toBe(true)
+    expect(pantalla.positions.length).toBe(3)
+  })
+
+  test('0x0001 - screen stays on, clears content', () => {
+    const pantalla = new Screen('Pantalla 1', 0xF000)
+    writeChars(pantalla, 'abc')
+    pantalla.setPos(120, 0x0001)
+    expect(pantalla.isOn()).toBe(true)
+    expect(pantalla.positions.length).toBe(0)
+  })
+
+  test('0x0002 - screen turns off, content preserved', () => {
+    const pantalla = new Screen('Pantalla 1', 0xF000)
+    writeChars(pantalla, 'abc')
+    pantalla.setPos(120, 0x0002)
+    expect(pantalla.isOn()).toBe(false)
+    pantalla.setPos(120, 0x0000)
+    expect(pantalla.isOn()).toBe(true)
+    expect(pantalla.positions.length).toBe(3)
+  })
+
+  test('0x0003 - screen turns off, clears content', () => {
+    const pantalla = new Screen('Pantalla 1', 0xF000)
+    writeChars(pantalla, 'abc')
+    pantalla.setPos(120, 0x0003)
+    expect(pantalla.isOn()).toBe(false)
+    expect(pantalla._positions.length).toBe(0)
+  })
+
 })
 
 test('Test update notifications', () => {


### PR DESCRIPTION
## Summary
- Fixed inverted polarity of bit 1 in the screen control register: bit 1 = 1 now correctly means screen OFF, bit 1 = 0 means screen ON (as per spec)
- Writing 0x0001 (clear screen) no longer unintentionally powers off the screen
- Added 4 tests covering all bit 0/bit 1 combinations of the control register
- Fixed existing test `Test powered off no characters` which used 0x0003 expecting screen ON, but bit 1 = 1 means OFF per spec — this test fails on main without this fix
- Bumped version to v1.0.4

## Test plan
- [x] All existing screen tests pass (including the corrected one)
- [x] New control register tests cover: 0x0000 (on, no clear), 0x0001 (on, clear), 0x0002 (off, no clear), 0x0003 (off, clear)
- [x] Manual verification in browser: writing to the control register behaves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)